### PR TITLE
Update egoventure.gd

### DIFF
--- a/addons/egoventure/egoventure.gd
+++ b/addons/egoventure/egoventure.gd
@@ -174,12 +174,14 @@ func change_scene(path: String):
 		current_scene = path
 		get_tree().change_scene_to(_scene_cache.get_scene(path))
 		yield(get_tree(),"idle_frame")
-		var is_four_side_room = false
+		var is_multi_side_room = false
 		for child in get_tree().current_scene.get_children():
 			if child.filename == \
-					"res://addons/egoventure/nodes/four_side_room.tscn":
-				is_four_side_room = true
-		if not is_four_side_room:
+					"res://addons/egoventure/nodes/four_side_room.tscn" or \
+					child.filename == \
+					"res://addons/egoventure/nodes/eight_side_room.tscn":
+				is_multi_side_room = true
+		if not is_multi_side_room:
 			check_cursor()
 	
 

--- a/addons/egoventure/egoventure.gd
+++ b/addons/egoventure/egoventure.gd
@@ -176,10 +176,9 @@ func change_scene(path: String):
 		yield(get_tree(),"idle_frame")
 		var is_multi_side_room = false
 		for child in get_tree().current_scene.get_children():
-			if child.filename == \
-					"res://addons/egoventure/nodes/four_side_room.tscn" or \
-					child.filename == \
-					"res://addons/egoventure/nodes/eight_side_room.tscn":
+			if child.filename in \
+					["res://addons/egoventure/nodes/four_side_room.tscn",
+					"res://addons/egoventure/nodes/eight_side_room.tscn"]:
 				is_multi_side_room = true
 		if not is_multi_side_room:
 			check_cursor()


### PR DESCRIPTION
fix: No check_cursor() for eight_side_room

Small fix to ensure that the check_cursor() function is also excluded for eight side room (similar to four side room).