### PR TITLE
feat: Add configuration for main menu item separation

### DIFF
--- a/addons/egoventure/nodes/main_menu.gd
+++ b/addons/egoventure/nodes/main_menu.gd
@@ -94,6 +94,8 @@ func configure(configuration: GameConfiguration):
 	
 	$Menu.theme = configuration.design_theme
 	
+	$Menu/MainMenu/Margin/VBox/MenuItems.add_constant_override("separation", configuration.menu_item_separation)
+	
 	# Set option labels to the menu button style
 	for label in [
 		"SpeechLabel", 

--- a/addons/egoventure/resources/game_configuration.gd
+++ b/addons/egoventure/resources/game_configuration.gd
@@ -28,6 +28,9 @@ var menu_button_effect_hover: AudioStream
 # A sound effect played when the a menu button is clicked
 var menu_button_effect_click: AudioStream
 
+# The main menu item separation
+var menu_item_separation: int = 30
+
 # The background texture for the save slots
 var menu_saveslots_background: Texture
 
@@ -198,6 +201,10 @@ func _get_property_list():
 		type = TYPE_OBJECT,
 		hint = PROPERTY_HINT_RESOURCE_TYPE,
 		hint_string = "AudioStream"
+	})
+	properties.append({
+		name = "menu_item_separation",
+		type = TYPE_INT
 	})
 	properties.append({
 		name = "menu_quit_confirmation",

--- a/configuration.tres
+++ b/configuration.tres
@@ -146,6 +146,7 @@ menu_music = ExtResource( 2 )
 menu_switch_effect = ExtResource( 4 )
 menu_button_effect_hover = ExtResource( 33 )
 menu_button_effect_click = ExtResource( 34 )
+menu_item_separation = 30
 menu_quit_confirmation = "Do you really want to leave Carol here?"
 menu_overwrite_confirmation = "Are you sure you want to overwrite a saved game?"
 menu_restart_confirmation = "You will lose all progress when starting a new game. Do you really want to restart?"


### PR DESCRIPTION
Adding a new configuration parameter to control the vertical distance of menu items in the main menu. This configuration can be used to support large fonts by decreasing the menu_item_separation configuration.

Fixes https://github.com/deep-entertainment/issues/issues/33