### PR TITLE
fix: ignore inventory in check cursor when it is disabled

### DIFF
--- a/addons/egoventure/nodes/check_cursor.gd
+++ b/addons/egoventure/nodes/check_cursor.gd
@@ -30,7 +30,7 @@ func _process(_delta):
 				"/root/MainMenu", # layer 125
 				"/root/DetailView", # layer 90
 				"/root/Notepad", # layer 2
-				"/root/Inventory/Canvas/InventoryAnchor/Panel", # layer 1
+				"/root/Inventory/Canvas/InventoryAnchor", # layer 1
 				get_tree().get_current_scene().get_path() # layer 0
 		]:
 			if !layer_processed:


### PR DESCRIPTION
Change starting node in check_cursor.gd for Inventory layer to ensure that disabled inventory is excluded from check.
Fixes deep-entertainment/issues#34