### PR TITLE
fix: cursor position calculation when resetting overridden cursor

### DIFF
--- a/addons/egoventure/types/cursors.gd
+++ b/addons/egoventure/types/cursors.gd
@@ -97,18 +97,13 @@ func override(
 #
 # - type: The type to reset (based on the Type enum)
 func reset(type):
-	var target_mouse_position = null
 	if EgoVenture.get("state") \
 			and type in EgoVenture.state.overridden_cursors:
-		target_mouse_position = get_viewport().get_mouse_position() - \
-				EgoVenture.state.overridden_cursors[type]['hotspot'] + \
-				_default_cursors[type].cursor_hotspot
 		EgoVenture.state.overridden_cursors.erase(type)
 	Speedy.set_custom_mouse_cursor(
 		_default_cursors[type].cursor,
 		CURSOR_MAP[type],
-		_default_cursors[type].cursor_hotspot,
-		target_mouse_position
+		_default_cursors[type].cursor_hotspot
 	)
 
 


### PR DESCRIPTION
Remove mouse target position calculation from cursors.gd reset function as this leads to a moving cursor hotspot when resetting an overridden cursor.
Fixes https://github.com/deep-entertainment/issues/issues/37