### PR TITLE
fix: Enhanced cross-fading of Boombox

### DIFF
--- a/addons/egoventure/nodes/boombox.gd
+++ b/addons/egoventure/nodes/boombox.gd
@@ -307,14 +307,18 @@ func _fade(
 		"volume_db",
 		VOLUME_MAX,
 		VOLUME_MIN,
-		time
+		time,
+		Tween.TRANS_EXPO,
+		Tween.EASE_IN
 	)
 	fader.interpolate_property(
 		fade_to,
 		"volume_db",
 		VOLUME_MIN,
 		VOLUME_MAX,
-		time
+		time,
+		Tween.TRANS_EXPO,
+		Tween.EASE_OUT
 	)
 	fader.start()
 	


### PR DESCRIPTION
Set TransitionType and EaseType in Boombox Tween to enhance cross-fading.
Fixes https://github.com/deep-entertainment/issues/issues/39