### PR TITLE
fix: ignore hotspot_indicator input event when WaitingScreen is visible

### DIFF
--- a/addons/egoventure/nodes/hotspots/hotspot.gd
+++ b/addons/egoventure/nodes/hotspots/hotspot.gd
@@ -68,7 +68,8 @@ func _process(_delta):
 # Hotspot indicator toggle
 func _input(event):
 	if show_indicator and \
-			(not DetailView.is_visible or DetailView.is_a_parent_of(self)):
+			(not DetailView.is_visible or DetailView.is_a_parent_of(self)) and \
+			not WaitingScreen.is_visible():
 		if event.is_action_pressed("hotspot_indicator"):
 			Speedy.hidden = true
 			_hotspot_indicator.show()


### PR DESCRIPTION
Fixes https://github.com/deep-entertainment/issues/issues/42