### PR TITLE
fix: menu item display issues

### DIFF
--- a/addons/egoventure/nodes/egoventure_menu_button.gd
+++ b/addons/egoventure/nodes/egoventure_menu_button.gd
@@ -56,20 +56,26 @@ func _ready():
 		StyleBoxEmpty.new()
 	)
 	_on_menuitem_hover_out()
+	
+	# disable focus for menu buttons
+	self.focus_mode = FOCUS_NONE
+	# keep font_color_press outside of button to match the menu_hover_button font
+	self.keep_pressed_outside = true
 
 
 # Switch fonts to allow more features on hover
 func _on_menuitem_hover():
-	add_font_override(
-		"font",
-		get_font(
-			"menu_button_hover",
-			"Button"
+	if !disabled:
+		add_font_override(
+			"font",
+			get_font(
+				"menu_button_hover",
+				"Button"
+			)
 		)
-	)
-	_effect_player.stream = EgoVenture.configuration.menu_button_effect_hover
-	_effect_player.play()
-	
+		_effect_player.stream = EgoVenture.configuration.menu_button_effect_hover
+		_effect_player.play()
+
 
 # Set menu font
 func _on_menuitem_hover_out():

--- a/addons/egoventure/nodes/main_menu.gd
+++ b/addons/egoventure/nodes/main_menu.gd
@@ -269,6 +269,7 @@ func _on_Load_pressed():
 # Cancel was pressed. Hide saveslots
 func _on_SaveLoad_Cancel_pressed():
 	$Menu/SaveSlots.hide()
+	$Menu/SaveSlots/VBox/Cancel.emit_signal("mouse_exited")
 
 
 # A save slot was selected
@@ -333,6 +334,7 @@ func _on_Options_pressed():
 # Return was pressed on the options screen
 func _on_Return_pressed():
 	$Menu/Options.hide()
+	$Menu/Options/CenterContainer/VBox/Return.emit_signal("mouse_exited")
 
 
 # The speech slider was changed

--- a/addons/egoventure/nodes/notepad.gd
+++ b/addons/egoventure/nodes/notepad.gd
@@ -157,6 +157,7 @@ func _on_Goals_gui_input(event):
 # Get out of notepad
 func _on_Close_pressed():
 	$Control.hide()
+	$Control/Close.emit_signal("mouse_exited")
 
 
 # Find the first unfulfilled hint of a goal


### PR DESCRIPTION
Fixes https://github.com/deep-entertainment/issues/issues/46
Contains:
- mouse_exited event gets raised when hiding Cancel or Return button of Load/Save or Options menu
- Hovering font (and button selection sound effect) is not used for disabled buttons
- Font color remains pressed outside of button area to match the hovered font
- Focus mode for menu buttons is switched off